### PR TITLE
Stopped using JSON.stringify() to compare radio button array props

### DIFF
--- a/lib/RadioGroup.tsx
+++ b/lib/RadioGroup.tsx
@@ -7,8 +7,25 @@ export default function RadioGroup({ layout = 'column', onPress, radioButtons }:
 
   const [radioButtonsArray, setRadioButtonsArray] = useState<RadioButtonProps[]>(radioButtons);
 
+  function areRadioButtonsEqual(a: RadioButtonProps, b: RadioButtonProps): boolean {
+    return a.color === b.color && a.containerStyle === b.containerStyle && a.disabled === b.disabled && a.id === b.id &&
+        a.label === b.label && a.labelStyle === b.labelStyle && a.layout === b.layout && a.selected === b.selected &&
+        a.size === b.size && a.value === b.value;
+  }
+
+  function areRadioButtonArraysEqual(a: RadioButtonProps[], b: RadioButtonProps[]): boolean {
+    if (a.length !== b.length) return false;
+    else {
+      for (let i = 0; i < a.length; i++) {
+        if (!areRadioButtonsEqual(a[i], b[i])) return false;
+      }
+
+      return true;
+    }
+  }
+
   useEffect(()=>{
-    if(JSON.stringify(radioButtons) !== JSON.stringify(radioButtonsArray)) {
+    if (!areRadioButtonArraysEqual(radioButtons, radioButtonsArray)) {
       setRadioButtonsArray(radioButtons);
     }
   },[radioButtons, radioButtonsArray])


### PR DESCRIPTION
Hello,

I changed the way in which arrays of RadioButtonProps elements are compared in RadioGroup.tsx. They were compared using JSON.stringify(), but as per the React docs "We do not recommend doing deep equality checks or using JSON.stringify() in shouldComponentUpdate(). It is very inefficient and will harm performance." - https://reactjs.org/docs/react-component.html#shouldcomponentupdate This will apply to comparisons in general, not just in implementations of shouldComponentUpdate().

Instead, I quickly implemented areRadioButtonArraysEqual() and areRadioButtonsEqual() to make this comparison without calling JSON.stringify() in order to improve the speed and efficiency of the comparison.

Thanks.