### PR TITLE
Adding focus and blur functionalities

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ Key | Type | Required | Default | Valid Values
 --- | --- | --- | --- | --- 
 borderColor | string | no | color | css color formats
 color | string | no | #444 | css color formats
+focusColor | string | no | | css color formats
 containerStyle | object | no | | react style
 disabled | boolean | no | false | true / false
 id | string | yes |  | unique string
@@ -110,6 +111,8 @@ label | string | no |  | any string
 labelStyle | object | no |  | react style
 layout | enum | no | row | row / column
 onPress | function | no |  | any function 
+onFocus | function | no |  | any function 
+onBlur | function | no |  | any function 
 selected | boolean | no | false | true / false
 size | number | no | 24 | positive numbers
 value | string | no |  | any string

--- a/lib/RadioButton.tsx
+++ b/lib/RadioButton.tsx
@@ -1,11 +1,12 @@
-import React from 'react';
-import { PixelRatio, Pressable, StyleSheet, Text, View } from 'react-native';
+import React, {useState} from 'react';
+import {PixelRatio, Pressable, StyleSheet, Text, View, TouchableOpacity} from 'react-native';
 
 import { RadioButtonProps } from './types';
 
 export default function RadioButton({
   borderColor,
   color = '#444',
+  focusColor,
   containerStyle,
   disabled = false,
   id,
@@ -13,6 +14,8 @@ export default function RadioButton({
   labelStyle,
   layout = 'row',
   onPress,
+  onFocus,
+  onBlur,
   selected = false,
   size = 24 }: RadioButtonProps) {
 
@@ -22,6 +25,8 @@ export default function RadioButton({
 
   let orientation: any = { flexDirection: 'row' }
   let margin: any = { marginLeft: 10 };
+
+  const [displayColor, setDisplayColor] = useState(color);
 
   if (layout === 'column') {
     orientation = { alignItems: 'center' };
@@ -37,16 +42,41 @@ export default function RadioButton({
     }
   }
 
+  function handleFocus() {
+    if (disabled) {
+      return null;
+    }
+    if (onFocus) {
+      onFocus(id);
+    }
+    if(focusColor) {
+      setDisplayColor(focusColor);
+    }
+  }
+
+  function handleBlur() {
+    if (disabled) {
+      return null;
+    }
+    if (onBlur) {
+      onBlur(id);
+    }
+
+    setDisplayColor(color);
+  }
+
   return (
-    <Pressable
+    <TouchableOpacity
       onPress={handlePress}
+      onFocus={handleFocus}
+      onBlur={handleBlur}
       style={[styles.container, orientation, { opacity: disabled ? 0.2 : 1 }, containerStyle]}
     >
       <View
         style={[
           styles.border,
           {
-            borderColor: borderColor || color,
+            borderColor: borderColor || displayColor,
             borderWidth,
             width: sizeFull,
             height: sizeFull,
@@ -56,7 +86,7 @@ export default function RadioButton({
         {selected && (
           <View
             style={{
-              backgroundColor: color,
+              backgroundColor: displayColor,
               width: sizeHalf,
               height: sizeHalf,
               borderRadius: sizeHalf
@@ -67,7 +97,7 @@ export default function RadioButton({
       {
         Boolean(label) && <Text style={[margin, labelStyle]}>{label}</Text>
       }
-    </Pressable>
+    </TouchableOpacity>
   )
 }
 

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -1,6 +1,7 @@
 export type RadioButtonProps = {
   borderColor?: string;
   color?: string;
+  focusColor?: string;
   containerStyle?: object;
   disabled?: boolean;
   id: string;
@@ -8,6 +9,8 @@ export type RadioButtonProps = {
   labelStyle?: object;
   layout?: 'row' | 'column';
   onPress?: (id: string) => void;
+  onFocus?: (id: string) => void;
+  onBlur?: (id: string) => void;
   selected?: boolean;
   size?: number;
   value?: string;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-radio-buttons-group",
-  "version": "2.2.5",
+  "version": "2.2.6",
   "description": "Simple and Best. An easy to use radio buttons for react native apps.",
   "main": "./lib/index.ts",
   "scripts": {


### PR DESCRIPTION
Hello :)

Using this module for an app I made, I had an issue - I needed it to work on Android TV as well, and although it worked - I couldn't tell where the focus was when moving with the remote's arrows. So I added focus and blur functionalities, as well as a new `focusColor` prop to set a wanted color for the currently focused radio button.

Also swapped the `Pressable` for a `TouchableOpacity` - the former doesn't have focus ability.

Hope you like it :)