### PR TITLE
auto-align button label and description text

### DIFF
--- a/lib/RadioButton.tsx
+++ b/lib/RadioButton.tsx
@@ -73,7 +73,12 @@ export default function RadioButton({
         </View>
         {Boolean(label) && <Text style={[margin, labelStyle]}>{label}</Text>}
       </Pressable>
-      {Boolean(description) && <Text style={[margin, descriptionStyle]}>{description}</Text>}
+      <View style={[styles.descriptionContainer, orientation]}>
+      <View style={{ width: sizeFull }}/>
+        { 
+          Boolean(description) && <Text style={[margin, descriptionStyle]}>{description}</Text> 
+        }
+      </View>
     </>
   );
 }
@@ -83,6 +88,11 @@ const styles = StyleSheet.create({
     alignItems: 'center',
     marginHorizontal: 10,
     marginVertical: 5,
+  },
+  descriptionContainer: {
+    alignItems: 'center',
+    marginHorizontal: 10,
+    marginBottom: 10,
   },
   border: {
     justifyContent: 'center',


### PR DESCRIPTION
Labels and descriptions should align per design best practices. This commit just does that automatically instead of having users set it manually. If additional space is necessary, they can still pass `margin` as a prop. 

Removed some unnecessary code from previous PR.