### PR TITLE
Refactoring of types in RadioButtonProps and RadioGroupProps

### DIFF
--- a/lib/types.ts
+++ b/lib/types.ts
@@ -1,15 +1,17 @@
+import { StyleProp, TextStyle, ViewStyle } from 'react-native';
+
 export type RadioButtonProps = {
   borderColor?: string;
   borderSize?: number;
   color?: string;
-  containerStyle?: object;
+  containerStyle?: StyleProp<ViewStyle>;
   description?: string;
-  descriptionStyle?: object;
+  descriptionStyle?: StyleProp<TextStyle>;
   disabled?: boolean;
   id: string;
   key?: string;
   label?: string;
-  labelStyle?: object;
+  labelStyle?: StyleProp<TextStyle>;
   layout?: 'row' | 'column';
   onPress?: (id: string) => void;
   selected?: boolean;
@@ -19,7 +21,7 @@ export type RadioButtonProps = {
 };
 
 export type RadioGroupProps = {
-  containerStyle?: object;
+  containerStyle?: StyleProp<ViewStyle>;
   layout?: 'row' | 'column';
   onPress?: (selectedId: string) => void;
   radioButtons: RadioButtonProps[];


### PR DESCRIPTION
This pull request performs a refactoring of the types in the `RadioButtonProps` and `RadioGroupProps` components. The changes include:
- Updated the `containerStyle`, `descriptionStyle`, and `labelStyle` properties to utilize `StyleProp` from `react-native`, providing improved typing and support for custom styles in these properties.
- Added necessary imports of `StyleProp`, `TextStyle`, and `ViewStyle` from `react-native` to ensure proper type inference.

These changes enhance the robustness and readability of the code by providing stronger typing for the property types used in the `RadioButton` and `RadioGroup` components.

Please review these changes and perform necessary testing to confirm that no errors or compatibility issues have been introduced

### Before
![image](https://github.com/ThakurBallary/react-native-radio-buttons-group/assets/19956031/3c940613-87f4-4c0b-bbc6-4c8e32a33110)

### After
![image](https://github.com/ThakurBallary/react-native-radio-buttons-group/assets/19956031/1859a072-f642-45b2-a6f4-e0358be044c6)
