### PR TITLE
feat: improve accessibility

### DIFF
--- a/lib/RadioButton.tsx
+++ b/lib/RadioButton.tsx
@@ -52,8 +52,12 @@ export default function RadioButton({
           { opacity: disabled ? 0.2 : 1 },
           containerStyle,
         ]}
+        disabled={disabled}
         testID={testID}
-        accessibilityLabel={accessibilityLabel}
+        accessibilityRole="radio"
+        accessibilityLabel={label || accessibilityLabel}
+        accessibilityHint={description}
+        accessibilityState={{ checked: selected, disabled }}
       >
         <View
           style={[

--- a/lib/RadioGroup.tsx
+++ b/lib/RadioGroup.tsx
@@ -4,7 +4,7 @@ import { StyleSheet, View } from 'react-native';
 import RadioButton from './RadioButton';
 import { RadioGroupProps } from './types';
 
-export default function RadioGroup({ containerStyle, layout = 'column', onPress, radioButtons, selectedId, testID}: RadioGroupProps) {
+export default function RadioGroup({ accessibilityLabel, containerStyle, layout = 'column', onPress, radioButtons, selectedId, testID}: RadioGroupProps) {
 
   function handlePress(id: string) {
     if(id !== selectedId && onPress) {
@@ -13,7 +13,12 @@ export default function RadioGroup({ containerStyle, layout = 'column', onPress,
   }
 
   return (
-    <View style={[styles.container, { flexDirection: layout }, containerStyle]} testID={testID}>
+    <View
+      style={[styles.container, { flexDirection: layout }, containerStyle]}
+      testID={testID}
+      accessibilityLabel={accessibilityLabel}
+      accessibilityRole="radiogroup"
+    >
       {radioButtons.map((button) => (
         <RadioButton
           {...button}

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -22,6 +22,7 @@ export type RadioButtonProps = {
 };
 
 export type RadioGroupProps = {
+  accessibilityLabel?: string;
   containerStyle?: StyleProp<ViewStyle>;
   layout?: 'row' | 'column';
   onPress?: (selectedId: string) => void;


### PR DESCRIPTION
Improved the accessibility of the radio group by adding the correct accessibility roles for both the radio group (`radiogroup` role), and the radio buttons (`radio` role) along with the corresponding accessibility states (`checked` and `disabled`) and labels.

I tested it with TalkBack on Android and it's working pretty well. _I wanted to record a video of me using it with TalkBack but I had problems recording video with audio on my Android device_.

Note, for the `RadioGroup` to be announced as a "radio group" by TalkBack you need to provide it with an `accessibilityLabel`. Once an `accessibilityLabel` is added, it should be announced as "***LABEL***, radio group"

Checked radio buttons are now announced "Checked, ***LABEL***, radio button, double tap to toggle" and unchecked radio buttons are announced "Not checked, ***LABEL***, radio button, double tap to toggle"