### PR TITLE
chore: enhance a11y defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ export default function App() {
 #### RadioButton
 Key | Type | Required | Default | Valid Values
 --- | --- | --- | --- | --- 
-accessibilityLabel | string | no | radio button | any string
+accessibilityLabel | string | no | Value of `label` | any string
 borderColor | string | no | color | css color formats
 borderSize | number | 2 | | positive numbers
 color | string | no | #444 | css color formats
@@ -122,7 +122,7 @@ value | string | no |  | any string
 #### RadioGroup
 Key | Type | Required | Default | Valid Values
 --- | --- | --- | --- | ---
-accessibilityLabel | string | no | radio group | any string
+accessibilityLabel | string | no | no | any string
 containerStyle | object | no | | react style
 layout | enum | no | column | row / column
 onPress | function | no | | any function

--- a/lib/RadioButton.tsx
+++ b/lib/RadioButton.tsx
@@ -4,7 +4,7 @@ import { PixelRatio, Pressable, StyleSheet, Text, View } from 'react-native';
 import { RadioButtonProps } from './types';
 
 export default function RadioButton({
-  accessibilityLabel = 'radio button',
+  accessibilityLabel,
   borderColor,
   borderSize = 2,
   color = '#444',
@@ -34,7 +34,7 @@ export default function RadioButton({
   }
 
   function handlePress() {
-    if(onPress) {
+    if (onPress) {
       onPress(id);
     }
   }
@@ -43,7 +43,7 @@ export default function RadioButton({
     <>
       <Pressable
         accessibilityHint={description}
-        accessibilityLabel={label || accessibilityLabel}
+        accessibilityLabel={accessibilityLabel || label}
         accessibilityRole="radio"
         accessibilityState={{ checked: selected, disabled }}
         disabled={disabled}
@@ -66,7 +66,8 @@ export default function RadioButton({
               height: sizeFull,
               borderRadius: sizeHalf,
             },
-          ]}>
+          ]}
+        >
           {selected && (
             <View
               style={{
@@ -80,7 +81,9 @@ export default function RadioButton({
         </View>
         {Boolean(label) && <Text style={[margin, labelStyle]}>{label}</Text>}
       </Pressable>
-      {Boolean(description) && <Text style={[margin, descriptionStyle]}>{description}</Text>}
+      {Boolean(description) && (
+        <Text style={[margin, descriptionStyle]}>{description}</Text>
+      )}
     </>
   );
 }

--- a/lib/RadioGroup.tsx
+++ b/lib/RadioGroup.tsx
@@ -5,7 +5,7 @@ import RadioButton from './RadioButton';
 import { RadioGroupProps } from './types';
 
 export default function RadioGroup({
-  accessibilityLabel = 'radio group',
+  accessibilityLabel,
   containerStyle,
   layout = 'column',
   onPress,


### PR DESCRIPTION
I've checked the latest changes made in 4343411, and TBH, I think these changes hurt accessibility instead of enhancing it.

1. I've removed the default `"radio button"` accessibility label added to radio buttons since it doesn't tell anything about the button itself and just tells the role of the view instead. I've replaced it to default to the value passed to the `label` property instead which is much more helpful since the `label` is actually required and is what is actually visible to users. I've also made it such that the user can provide a custom `accessibilityLabel` if he doesn't want to default to the `label` property.
2. I've removed the default `"radio group"` accessibility label added to the radio group for the same reason as the radio button, it doesn't tell anything about the element. But the attribute is there if the developer cares about accessibility he can add a better `accessibilityLabel`.

I'm open to discussion about these changes or anything related so that we can enhance the accessibility of this library for users.