### PR TITLE
expose labelStyle to the RadioGroup component

### DIFF
--- a/lib/RadioGroup.tsx
+++ b/lib/RadioGroup.tsx
@@ -1,19 +1,20 @@
-import React from "react";
-import { StyleSheet, View } from "react-native";
+import React from 'react';
+import { StyleSheet, View } from 'react-native';
 
-import RadioButton from "./RadioButton";
-import { RadioGroupProps } from "./types";
+import RadioButton from './RadioButton';
+import { RadioGroupProps } from './types';
 
 export default function RadioGroup({
   accessibilityLabel,
   containerStyle,
   labelStyle,
-  layout = "column",
+  layout = 'column',
   onPress,
   radioButtons,
   selectedId,
-  testID,
+  testID
 }: RadioGroupProps) {
+
   function handlePress(id: string) {
     if (id !== selectedId && onPress) {
       onPress(id);
@@ -37,11 +38,12 @@ export default function RadioGroup({
         />
       ))}
     </View>
-  );
+  )
+
 }
 
 const styles = StyleSheet.create({
   container: {
-    alignItems: "center",
-  },
+    alignItems: 'center',
+  }
 });

--- a/lib/RadioGroup.tsx
+++ b/lib/RadioGroup.tsx
@@ -1,19 +1,19 @@
-import React from 'react';
-import { StyleSheet, View } from 'react-native';
+import React from "react";
+import { StyleSheet, View } from "react-native";
 
-import RadioButton from './RadioButton';
-import { RadioGroupProps } from './types';
+import RadioButton from "./RadioButton";
+import { RadioGroupProps } from "./types";
 
 export default function RadioGroup({
   accessibilityLabel,
   containerStyle,
-  layout = 'column',
+  labelStyle,
+  layout = "column",
   onPress,
   radioButtons,
   selectedId,
-  testID
+  testID,
 }: RadioGroupProps) {
-
   function handlePress(id: string) {
     if (id !== selectedId && onPress) {
       onPress(id);
@@ -33,15 +33,15 @@ export default function RadioGroup({
           key={button.id}
           selected={button.id === selectedId}
           onPress={() => handlePress(button.id)}
+          labelStyle={labelStyle}
         />
       ))}
     </View>
-  )
-
+  );
 }
 
 const styles = StyleSheet.create({
   container: {
-    alignItems: 'center',
-  }
+    alignItems: "center",
+  },
 });


### PR DESCRIPTION
A simple addition that allows users to pass default styles to their radio button labels without needing to add styling to the radio button data. 

An example of usage:
```
<RadioGroup
  labelStyle={{
    fontSize: 20,
    marginBottom: 10,
    color: '#ffffff',
  }}
/>
```