### PR TITLE
LabelStyle from RadioButton not being considered

### DIFF
--- a/lib/RadioGroup.tsx
+++ b/lib/RadioGroup.tsx
@@ -32,7 +32,7 @@ export default function RadioGroup({
         <RadioButton
           {...button}
           key={button.id}
-          labelStyle={labelStyle}
+          labelStyle={button.labelStyle || labelStyle}
           selected={button.id === selectedId}
           onPress={() => handlePress(button.id)}
         />


### PR DESCRIPTION
A simple fix to take into consideration if a RadioButton already has a labelStyle property. If it doesn't, it applies the labelStyle from the RadioGroup props.