### PR TITLE
add ability to use `ReactNode` as label or description

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,12 +106,12 @@ borderColor | string | no | color | css color formats
 borderSize | number | 2 | | positive numbers
 color | string | no | #444 | css color formats
 containerStyle | object | no | | react style
-description | string | no |  | any string
-descriptionStyle | object | no |  | react style
+description | ReactNode | no |  | any react node, texts are rendered in a `Text`-component
+descriptionStyle | object | no |  | react style, only used if `description` is not a react component
 disabled | boolean | no | false | true / false
 id | string | yes |  | unique string
-label | string | no |  | any string
-labelStyle | object | no |  | react style
+label | ReactNode | no |  | any react node, texts are rendered in a `Text`-component
+labelStyle | object | no |  | react style, only used if `label` is not a react component
 layout | enum | no | row | row / column
 onPress | function | no |  | any function 
 selected | boolean | no | false | true / false

--- a/lib/RadioButton.tsx
+++ b/lib/RadioButton.tsx
@@ -53,8 +53,8 @@ export default function RadioButton({
   return (
     <>
       <Pressable
-        accessibilityHint={typeof description === "string" ? description : ""}
-        accessibilityLabel={accessibilityLabel || (typeof label === "string" ? label: null)}
+        accessibilityHint={typeof description === "string" ? description : undefined}
+        accessibilityLabel={accessibilityLabel || (typeof label === "string" ? label: undefined)}
         accessibilityRole="radio"
         accessibilityState={{ checked: selected, disabled }}
         disabled={disabled}

--- a/lib/RadioButton.tsx
+++ b/lib/RadioButton.tsx
@@ -39,6 +39,17 @@ export default function RadioButton({
     }
   }
 
+  const labelComp = React.isValidElement(label) ? (
+    label
+  ) : Boolean(label) ? (
+    <Text style={[margin, labelStyle]}>{label}</Text>
+  ) : null;
+  const descComp = React.isValidElement(description) ? (
+    description
+  ) : Boolean(description) ? (
+    <Text style={[margin, descriptionStyle]}>{description}</Text>
+  ) : null;
+
   return (
     <>
       <Pressable
@@ -79,11 +90,9 @@ export default function RadioButton({
             />
           )}
         </View>
-        {Boolean(label) && <Text style={[margin, labelStyle]}>{label}</Text>}
+        {labelComp}
       </Pressable>
-      {Boolean(description) && (
-        <Text style={[margin, descriptionStyle]}>{description}</Text>
-      )}
+      {descComp}
     </>
   );
 }

--- a/lib/RadioButton.tsx
+++ b/lib/RadioButton.tsx
@@ -53,8 +53,8 @@ export default function RadioButton({
   return (
     <>
       <Pressable
-        accessibilityHint={description}
-        accessibilityLabel={accessibilityLabel || label}
+        accessibilityHint={typeof description === "string" ? description : ""}
+        accessibilityLabel={accessibilityLabel || (typeof label === "string" ? label: null)}
         accessibilityRole="radio"
         accessibilityState={{ checked: selected, disabled }}
         disabled={disabled}

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -1,3 +1,4 @@
+import {ReactNode} from "react";
 import { StyleProp, TextStyle, ViewStyle } from 'react-native';
 
 export type RadioButtonProps = {
@@ -6,12 +7,12 @@ export type RadioButtonProps = {
   borderSize?: number;
   color?: string;
   containerStyle?: StyleProp<ViewStyle>;
-  description?: string;
+  description?: ReactNode;
   descriptionStyle?: StyleProp<TextStyle>;
   disabled?: boolean;
   id: string;
   key?: string;
-  label?: string;
+  label?: ReactNode;
   labelStyle?: StyleProp<TextStyle>;
   layout?: 'row' | 'column';
   onPress?: (id: string) => void;


### PR DESCRIPTION
This PR would allow users to use any valid `ReactNode` as a label or description. This way users have more control over how  the buttons and their content are displayed.

closes #74 